### PR TITLE
Microsoft store support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Some 21:9, 32:9 and 48:9 images below. More images can be found over at [Nexus M
   - Linux: [hephaistos-linux.zip](https://github.com/nbusseneau/hephaistos/releases/latest/download/hephaistos-linux.zip)
   - **[Advanced]** Python: [hephaistos-python.zip](https://github.com/nbusseneau/hephaistos/releases/latest/download/hephaistos-python.zip)
 - Extract the archive. You should get:
-  - Windows: `hephaistos.exe` executable (for Windows Store version read [Windows Store version](#windows-store-version) below).
+  - Windows: `hephaistos.exe` executable (for Microsoft Store version read [Microsoft Store version](#microsoft-store-version) below).
   - MacOS / Linux: `hephaistos` executable.
   - Python: `hephaistos`, `hephaistos-data` and `sjson` directories.
 - Move all extracted files to Hades main directory. Hephaistos must be sitting right next to the default Hades directories:
@@ -220,9 +220,9 @@ Use `--force` to repatch and create new backups:
 ```bat
 hephaistos patch 3440 1440 --force
 ```
-# Windows Store version
+# Microsoft Store version
 
-Hephaistos is now able to patch the Windows Store version of Hades thanks to the new 'advanced installation and management features' added to latest preview version of the Xbox app. This allows you to install Windows Store games outside of the WindowsApps folder and, for Hades at least, the files are unencrypted and editable&nbsp;🥳
+Hephaistos is now able to patch the Microsoft Store version of Hades thanks to the new 'advanced installation and management features' added to latest preview version of the Xbox app. This allows you to install Microsoft Store games outside of the WindowsApps folder and, for Hades at least, the files are unencrypted and editable&nbsp;🥳
 
 To get access to the latest preview version of the Xbox app on PC follow the instructions [in this article](https://news.xbox.com/en-us/2021/11/18/advanced-installation-and-management-features-available-for-insiders-through-the-xbox-app-for-windows/)
 
@@ -234,9 +234,9 @@ Once you have followed the steps in the article above install Hades to your new 
 >
 > This is a bug with the 'advanced installation and management features' that occurs specifically with Hades. This is not an issue with Hephaistos and will happen regardless of if you have patched Hades with Hephaistos or not if this feature is turned on.
 >
-> To fix this uninstall Hades from your PC and re-download it through the Xbox app (and then repatch again with Hephaistos). This will have to be done every time Hades is closed.
+> To fix this uninstall Hades from your PC and re-download it through the Xbox app (and then repatch again with Hephaistos). This will have to be done every time Hades is opened and closed.
 >
-> Unfortunately this feature needs to be turned on for Hephiastos to work, so until this is fixed by Microsoft this will need to be done every time to launch the MS version of Hades with Hephaistos.
+> Unfortunately this feature needs to be turned on for Hephaistos to work so there is no avoiding this, so until this is fixed by Microsoft this will need to be done every time to launch the MS version of Hades if you want to patch it with Hephaistos.
 
 # Under the hood
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Hades
 └── hephaistos.exe
 ```
 
+⚠️&nbsp; NOTE: For the Microsoft Store version there are 2 Content folders, one inside the other! Hephaistos must be copied inside the 1st Content folder only!
+
+It should look something like this
+
+```
+Hades
+└───Content
+    ├───Content
+    ├───ja
+    └──hephaistos.exe
+```
+
 > ⚠️&nbsp;If you don't know where Hades is, Hephaistos can try to give you a tip by auto-detecting from Steam and Epic Games configuration files:
 >
 > - Windows: run `hephaistos.exe`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Some 21:9, 32:9 and 48:9 images below. More images can be found over at [Nexus M
   - Linux: [hephaistos-linux.zip](https://github.com/nbusseneau/hephaistos/releases/latest/download/hephaistos-linux.zip)
   - **[Advanced]** Python: [hephaistos-python.zip](https://github.com/nbusseneau/hephaistos/releases/latest/download/hephaistos-python.zip)
 - Extract the archive. You should get:
-  - Windows: `hephaistos.exe` executable.
+  - Windows: `hephaistos.exe` executable (for Windows Store version read [Windows Store version](#windows-store-version) below).
   - MacOS / Linux: `hephaistos` executable.
   - Python: `hephaistos`, `hephaistos-data` and `sjson` directories.
 - Move all extracted files to Hades main directory. Hephaistos must be sitting right next to the default Hades directories:
@@ -220,6 +220,23 @@ Use `--force` to repatch and create new backups:
 ```bat
 hephaistos patch 3440 1440 --force
 ```
+# Windows Store version
+
+Hephaistos is now able to patch the Windows Store version of Hades thanks to the new 'advanced installation and management features' added to latest preview version of the Xbox app. This allows you to install Windows Store games outside of the WindowsApps folder and, for Hades at least, the files are unencrypted and editable&nbsp;🥳
+
+To get access to the latest preview version of the Xbox app on PC follow the instructions [in this article](https://news.xbox.com/en-us/2021/11/18/advanced-installation-and-management-features-available-for-insiders-through-the-xbox-app-for-windows/)
+
+Once you have followed the steps in the article above install Hades to your new install location and once installed patch using Hephaistos following the [instructions above](#install)
+
+## Known Bugs
+
+> ⚠️&nbsp;Unfortunately there is a bug with this new update to the Xbox app where Hades will fail to launch after opening it for the first time.
+>
+> This is a bug with the 'advanced installation and management features' that occurs specifically with Hades. This is not an issue with Hephaistos and will happen regardless of if you have patched Hades with Hephaistos or not if this feature is turned on.
+>
+> To fix this uninstall Hades from your PC and re-download it through the Xbox app (and then repatch again with Hephaistos). This will have to be done every time Hades is closed.
+>
+> Unfortunately this feature needs to be turned on for Hephiastos to work, so until this is fixed by Microsoft this will need to be done every time to launch the MS version of Hades with Hephaistos.
 
 # Under the hood
 

--- a/hephaistos/helpers.py
+++ b/hephaistos/helpers.py
@@ -30,7 +30,7 @@ class HUD(str, Enum):
 
 
 HADES_DIR_DIRS_WINDOWS_LINUX = ['Content', 'x64', 'x64Vk', 'x86']
-HADES_DIR_DIRS_WINDOWS_STORE = ['Content']
+HADES_DIR_DIRS_MICROSOFT_STORE = ['Content']
 HADES_DIR_DIRS_MACOS = ['Game.macOS.app']
 
 
@@ -71,20 +71,20 @@ TRY_EPIC_MACOS = [
     os.path.expanduser(r'~/Library/Application Support/Epic/EpicGamesLauncher/Data/Manifests'),
 ]
 TRY_EPIC = TRY_EPIC_MACOS if platform.system() == 'Darwin' else TRY_EPIC_WINDOWS
-TRY_WINDOWS_STORE = 'appmanifest.xml'
+TRY_MICROSOFT_STORE = 'appmanifest.xml'
 DISPLAY_NAME_REGEX = re.compile(r'"DisplayName": "(.*)"')
 INSTALL_LOCATION_REGEX = re.compile(r'"InstallLocation": "(.*)"')
 
 
 def __get_hades_dirs() -> list[str]:
-    return HADES_DIR_DIRS_MACOS if platform.system() == 'Darwin' else HADES_DIR_DIRS_WINDOWS_STORE if config.hades_dir.joinpath(TRY_WINDOWS_STORE) else HADES_DIR_DIRS_WINDOWS_LINUX
+    return HADES_DIR_DIRS_MACOS if platform.system() == 'Darwin' else HADES_DIR_DIRS_MICROSOFT_STORE if config.hades_dir.joinpath(TRY_MICROSOFT_STORE) else HADES_DIR_DIRS_WINDOWS_LINUX
 
 def try_detect_hades_dirs() -> list[Path]:
     """Try to detect Hades directory from Steam and Epic Games files."""
     potential_hades_dirs: list[Path] = []
-    for wstore_appmanifest_file in [config.hades_dir.joinpath(TRY_WINDOWS_STORE)]:
-        if wstore_appmanifest_file.exists():
-            LOGGER.debug(f"Found Windows Store App Manifest XML file at '{wstore_appmanifest_file}'")
+    for mstore_appmanifest_file in [config.hades_dir.joinpath(TRY_MICROSOFT_STORE)]:
+        if mstore_appmanifest_file.exists():
+            LOGGER.debug(f"Found Microsoft Store App Manifest XML file at '{mstore_appmanifest_file}'")
             potential_hades_dirs.append(config.hades_dir)
     for steam_library_file in [Path(item).joinpath('libraryfolders.vdf') for item in TRY_STEAM]:
         if steam_library_file.exists():
@@ -105,7 +105,7 @@ TRY_SAVE_WINDOWS_DEFAULT = [
     os.path.expanduser(r'~\Documents\Saved Games\Hades'),
     os.path.expanduser(r'~\Documents\OneDrive\Saved Games\Hades'),
 ]
-TRY_SAVE_WINDOWS_STORE = [
+TRY_SAVE_MICROSOFT_STORE = [
     os.path.expanduser(r'~\AppData\Local\Packages\SupergiantGamesLLC.Hades_q53c1yqmx7pha\SystemAppData\wgs')
 ]
 TRY_SAVE_MACOS = [
@@ -116,7 +116,7 @@ TRY_SAVE_LINUX = [
 ]
 if platform.system() == 'Darwin': TRY_SAVE = TRY_SAVE_MACOS
 elif platform.system() == 'Linux': TRY_SAVE = TRY_SAVE_LINUX
-elif [Path(save_dir).exists() for save_dir in TRY_SAVE_WINDOWS_STORE] : TRY_SAVE = TRY_SAVE_WINDOWS_STORE
+elif [Path(save_dir).exists() for save_dir in TRY_SAVE_MICROSOFT_STORE] : TRY_SAVE = TRY_SAVE_MICROSOFT_STORE
 else:
     # Try to detect actual path to Documents folder from registry, in case user
     # has moved its Documents folder somewhere else than `%USERDIR%\Documents`
@@ -140,9 +140,9 @@ def try_get_profile_sjson_files() -> list[Path]:
     for save_dir in save_dirs:
         if save_dir.exists():
             LOGGER.debug(f"Found save directory at '{save_dir}'")
-            if save_dirs == [Path(item) for item in TRY_SAVE_WINDOWS_STORE]:
-                LOGGER.debug(f"Save directory at '{save_dir}' is from Windows Store")
-                profiles = __parse_ws_sjson_profile_files(save_dir)
+            if save_dirs == [Path(item) for item in TRY_SAVE_MICROSOFT_STORE]:
+                LOGGER.debug(f"Save directory at '{save_dir}' is from Microsoft Store version")
+                profiles = __parse_ms_sjson_profile_files(save_dir)
             else:
                 profiles = [item for item in save_dir.glob('Profile*.sjson')]
             if profiles:
@@ -153,9 +153,9 @@ def try_get_profile_sjson_files() -> list[Path]:
     LOGGER.warning(msg)
     return []
 
-# All Windows Store files in save location are named as random hexadecimal string with no file extensions and
+# All Microsoft Store files in save location are named as random hexadecimal strings with no file extensions and
 # change each time Hades is installed. Get all files from save location and tests which can be parsed as sjson
-def __parse_ws_sjson_profile_files(save_dir: Path) -> list[Path]:
+def __parse_ms_sjson_profile_files(save_dir: Path) -> list[Path]:
     LOGGER.debug(f"Detecting actual .sjson files from '{save_dir}'")
     sjson_files: list[Path] = []
     for file in save_dir.rglob('*'):

--- a/hephaistos/patchers.py
+++ b/hephaistos/patchers.py
@@ -71,8 +71,8 @@ ENGINES_WINDOWS_LINUX = {
     'Vulkan': 'x64Vk/EngineWin64sv.dll',
     '32-bit': 'x86/EngineWin32s.dll',
 }
-ENGINES_WINDOWS_STORE = {
-    'DirectXWS': 'EngineWin64s.dll',
+ENGINES_MICROSOFT_STORE = {
+    'DirectXMS': 'EngineWin64s.dll',
 }
 ENGINES_MACOS = {
     'Metal': 'Game.macOS.app/Contents/MacOS/Game.macOS',
@@ -111,7 +111,8 @@ HEX_PATCHES: dict[str, HexPatch] = {
         'Metal': {
             'expected_subs': 232,
         },
-        'DirectXWS': {
+        # Microsoft Store version
+        'DirectXMS': {
             'expected_subs': 246,
         },
     },
@@ -139,7 +140,8 @@ HEX_PATCHES: dict[str, HexPatch] = {
         'Metal': {
             'expected_subs': 229,
         },
-        'DirectXWS': {
+        # Microsoft Store version
+        'DirectXMS': {
             'expected_subs': 490,
         },
     },
@@ -147,7 +149,7 @@ HEX_PATCHES: dict[str, HexPatch] = {
 
 
 def __get_engines() -> dict[str, str]:
-    return ENGINES_MACOS if platform.system() == 'Darwin' else ENGINES_WINDOWS_STORE if config.hades_dir.joinpath(helpers.TRY_WINDOWS_STORE) else ENGINES_WINDOWS_LINUX
+    return ENGINES_MACOS if platform.system() == 'Darwin' else ENGINES_MICROSOFT_STORE if config.hades_dir.joinpath(helpers.TRY_MICROSOFT_STORE) else ENGINES_WINDOWS_LINUX
 
 def __get_engine_specific_hex_patches(engine) -> None:
     hex_patches = copy.deepcopy(HEX_PATCHES)


### PR DESCRIPTION
Hey, have been playing with this mod since the news that, with the beta Xbox app, you can now install games outside of the WindowsApps folder and have managed to get the Hephaistos patcher to work with the Microsoft Store version of Hades.

I have tested these changes at 5120x1440 (with the expanded HUD) and have played from the beginning to Asphodel but all seems to be working fine and menus look exactly what you would expect.

I only have the Microsoft Store version so unfortunately I am unable to test that my changes haven't caused a regression on patching other versions of Hades. Also this has only been tested by running the python scripts, not sure what you use to package these up into an executable.

Also admittedly my approach to this was to just run your existing scripts on the Microsoft Store version and fix any errors. You may notice the sub counts for the engine .dll are slightly different, I couldn't say why but just changing the expected_sub counts seemed to work and, so far, haven't seen any issues. 

There is a bug with the beta Xbox app meaning you have to re-install Hades every time you want to play which isn't ideal (unrelated to Hephaistos, see my updated readme). Might be worth holding off on releasing until this new feature is out of beta?

Happy for you to do what you want with this, was just mainly making you aware that Microsoft Store support is possible and what I changed in your scripts to make it work.